### PR TITLE
Alt::some() and Alt::many()

### DIFF
--- a/src/main/java/org/highj/function/F1.java
+++ b/src/main/java/org/highj/function/F1.java
@@ -4,10 +4,7 @@ import org.derive4j.hkt.__;
 import org.derive4j.hkt.__2;
 import org.highj.data.Maybe;
 import org.highj.data.Memo;
-import org.highj.data.tuple.T0;
-import org.highj.data.tuple.T2;
-import org.highj.data.tuple.T3;
-import org.highj.data.tuple.T4;
+import org.highj.data.tuple.*;
 import org.highj.function.f1.*;
 import org.highj.typeclass0.group.Monoid;
 
@@ -139,4 +136,20 @@ public interface F1<A, B> extends __2<F1.µ, A, B>, Function<A, B> {
     static <A, B> F1<A, B> fromFunction(Function<A, B> fn) {
         return fn::apply;
     }
+
+    static <A> A fix(Function<T1<A>,A> k) {
+        class Util {
+            private Maybe<A> resultOp = Maybe.Nothing();
+        }
+        final Util util = new Util();
+        A result = k.apply(T1.of$(() -> {
+            if (util.resultOp.isNothing()) {
+                throw new RuntimeException("Value read before it was written to.");
+            }
+            return util.resultOp.get();
+        }));
+        util.resultOp = Maybe.Just(result);
+        return result;
+    }
+
 }

--- a/src/main/java/org/highj/typeclass1/LazifyH.java
+++ b/src/main/java/org/highj/typeclass1/LazifyH.java
@@ -1,0 +1,14 @@
+package org.highj.typeclass1;
+
+import org.derive4j.hkt.__;
+import org.highj.data.tuple.T1;
+
+/**
+ * All types in Haskell are lazy by default, which leads to elegant implementations of
+ * some methods that would be otherwise quite ugly in a strict language.
+ * LazifyH is a type class that represents a high order type that are self lazy-embedding capable.
+ * Libraries like derive4j can auto-generate self lazy-embeddedness automatically for an ADT.
+ */
+public interface LazifyH<F> {
+    <A> __<F,A> lazifyH(T1<__<F,A>> a);
+}

--- a/src/main/java/org/highj/typeclass1/alternative/Alt.java
+++ b/src/main/java/org/highj/typeclass1/alternative/Alt.java
@@ -2,7 +2,6 @@ package org.highj.typeclass1.alternative;
 
 import org.derive4j.hkt.__;
 import org.highj.data.List;
-import org.highj.data.tuple.T1;
 import org.highj.typeclass1.LazifyH;
 import org.highj.typeclass0.group.Semigroup;
 import org.highj.typeclass1.functor.Functor;
@@ -17,15 +16,11 @@ public interface Alt<F> extends Functor<F> {
     }
 
     default <A> __<F,List<A>> some(Applicative<F> applicative, LazifyH<F> lazify, __<F,A> fa) {
-        return applicative.apply2(
-            (A head) -> (List<A> tail) -> List.Cons(head, tail),
-            fa,
-            lazify.lazifyH(T1.of$(() -> many(applicative, lazify, fa)))
-        );
+        return AltUtil.some_many(this, applicative, lazify, fa)._1();
     }
 
     default <A> __<F,List<A>> many(Applicative<F> applicative, LazifyH<F> lazify, __<F,A> fa) {
-        return mplus(some(applicative, lazify, fa), applicative.pure(List.Nil()));
+        return AltUtil.some_many(this, applicative, lazify, fa)._2();
     }
 
 }

--- a/src/main/java/org/highj/typeclass1/alternative/Alt.java
+++ b/src/main/java/org/highj/typeclass1/alternative/Alt.java
@@ -1,18 +1,31 @@
 package org.highj.typeclass1.alternative;
 
 import org.derive4j.hkt.__;
+import org.highj.data.List;
+import org.highj.data.tuple.T1;
+import org.highj.typeclass1.LazifyH;
 import org.highj.typeclass0.group.Semigroup;
 import org.highj.typeclass1.functor.Functor;
+import org.highj.typeclass1.monad.Applicative;
 
 public interface Alt<F> extends Functor<F> {
 
-    public <A> __<F, A> mplus(__<F, A> first, __<F, A> second);
+    <A> __<F, A> mplus(__<F, A> first, __<F, A> second);
 
-    public default <A> Semigroup<__<F, A>> asSemigroup() {
+    default <A> Semigroup<__<F, A>> asSemigroup() {
         return Alt.this::mplus;
     }
 
-    //public <F,A> __<F,List<A>> some(Applicative<F> applicative, __<F,A> fa);
-    //public <F,A> __<F,List<A>> many(Applicative<F> applicative, __<F,A> fa);
+    default <A> __<F,List<A>> some(Applicative<F> applicative, LazifyH<F> lazify, __<F,A> fa) {
+        return applicative.apply2(
+            (A head) -> (List<A> tail) -> List.Cons(head, tail),
+            fa,
+            lazify.lazifyH(T1.of$(() -> many(applicative, lazify, fa)))
+        );
+    }
+
+    default <A> __<F,List<A>> many(Applicative<F> applicative, LazifyH<F> lazify, __<F,A> fa) {
+        return mplus(some(applicative, lazify, fa), applicative.pure(List.Nil()));
+    }
 
 }

--- a/src/main/java/org/highj/typeclass1/alternative/AltUtil.java
+++ b/src/main/java/org/highj/typeclass1/alternative/AltUtil.java
@@ -1,0 +1,29 @@
+package org.highj.typeclass1.alternative;
+
+import org.derive4j.hkt.__;
+import org.highj.data.List;
+import org.highj.data.tuple.T1;
+import org.highj.data.tuple.T2;
+import org.highj.function.F1;
+import org.highj.typeclass1.LazifyH;
+import org.highj.typeclass1.monad.Applicative;
+
+class AltUtil {
+
+    static <F,A> T2<__<F,List<A>>,__<F,List<A>>> some_many(Alt<F> alt, Applicative<F> applicative, LazifyH<F> lazify, __<F,A> fa) {
+        return F1.fix(
+            (T1<T2<__<F,List<A>>,__<F,List<A>>>> rec) -> {
+                T2<T1<__<F,List<A>>>,T1<__<F,List<A>>>> rec2 = T2.of(T1.of$(() -> rec._1()._1()), T1.of$(() -> rec._1()._2()));
+                return T2.of(
+                    applicative.apply2(
+                        (A head) -> (List<A> tail) -> List.Cons(head, tail),
+                        fa,
+                        lazify.lazifyH(rec2._2())
+                    ),
+                    alt.mplus(lazify.lazifyH(rec2._1()), applicative.pure(List.Nil()))
+                );
+            }
+        );
+    }
+
+}


### PR DESCRIPTION
Haskell types all support lazyness by default. To make ```Alt::some()``` and ```Alt::many()``` even possible in a strict language we need to insure the data type ```__<F,A>``` supports lazyness under the hood, that is where the type class ```LazifyH``` comes in.