### PR TITLE
Lam2CCC: start of runtime compilation of lambda calculus to CCC.

### DIFF
--- a/src/main/java/org/highj/typeclass2/category/Lam2CCC.java
+++ b/src/main/java/org/highj/typeclass2/category/Lam2CCC.java
@@ -3,6 +3,8 @@ package org.highj.typeclass2.category;
 import org.derive4j.hkt.__2;
 import org.derive4j.hkt.__3;
 import org.highj.function.F1;
+import org.highj.function.F2;
+import org.highj.function.F3;
 
 public class Lam2CCC<K,Tensor,Hom,Unit> {
     private final CCC<K,Tensor,Hom,Unit> ccc;
@@ -25,16 +27,29 @@ public class Lam2CCC<K,Tensor,Hom,Unit> {
     public <I,X,A,B> __2<K,I,__3<Hom,K,A,B>> lam(F1<__2<K,__3<X,A>,__2<K,__3<Tensor,K,I,A>,B>> f) {}
     */
 
-    public <I,A,B> __2<K,I,__3<Hom,K,A,B>> lam_1(F1<__2<K,__3<Tensor,K,I,A>,A>,__2<K,__3<Tensor,K,I,A>,B>> f) {
+    public <I,A,B> __2<K,I,__3<Hom,K,A,B>> lam1(F1<__2<K,__3<Tensor,K,I,A>,A>,__2<K,__3<Tensor,K,I,A>,B>> f) {
         return ccc.curry(f.apply(ccc.exr()));
     }
 
-    public <I,X,A,B> __2<K,I,__3<Hom,K,A,B>> lam_2(F1<__2<K,__3<Tensor,K,X,__3<Tensor,K,I,A>>,A>,__2<K,__3<Tensor,K,I,A>,B>> f) {
-        return ccc.curry(f.apply(ccc.dot(ccc.exr(), ccc.exr())));
+    public <I,A,B,C> __2<K,I,__3<Hom,K,A,__3<Hom,K,B,C>>> lam2(F2<__2<K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,A>,__2<K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,B>,__2<K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>> f) {
+        return ccc.curry(ccc.curry(f.apply(ccc.dot(ccc.exr(), ccc.exl()), ccc.exr())));
     }
 
-    public <I,X1,X2,A,B> __2<K,I,__3<Hom,K,A,B>> lam_3(F1<__2<K,__3<Tensor,K,X1,__3<Tensor,K,X2,__3<Tensor,K,I,A>>>,A>,__2<K,__3<Tensor,K,I,A>,B>> f) {
-        return ccc.curry(f.apply(ccc.dot(ccc.exr(), ccc.dot(ccc.exr(), ccc.exr()))));
+    public <I,A,B,C,D> __2<K,I,__3<Hom,K,A,__3<Hom,K,B,__3<Hom,K,C,D>>>> lam3(F3<__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,A>,__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,B>,__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,C>,__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,D>> f) {
+        return ccc.curry(ccc.curry(ccc.curry(f.apply(ccc.dot(ccc.exr(), ccc.dot(ccc.exl(), ccc.exl())), ccc.dot(ccc.exr(), ccc.exl()), ccc.exr()))));
+    }
+
+    public <I,A,B,C> __2<K,I,__3<Hom,K,A,__3<Hom,K,B,C>>> lam2Curried(F1<__2<K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,A>,F1<__2<K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,B>,__2<K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>>> f) {
+        return lam2((x, y) -> f.apply(x).apply(y));
+    }
+
+    public <I,A,B,C,D> __2<K,I,__3<Hom,K,A,__3<Hom,K,B,__3<Hom,K,C,D>>>> lam3Curried(F1<__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,A>,F1<__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,B>,F1<__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,C>,__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,D>>>> f) {
+        return lam3((x, y, z) -> f.apply(x).apply(y).apply(z));
+    }
+
+    private void test() {
+        // type checks
+        apply(lam2Curried(x -> y -> x), null);
     }
 
     // ($) :: forall k i a b. CCC k => k i (Hom k a b) -> k i a -> k i b

--- a/src/main/java/org/highj/typeclass2/category/Lam2CCC.java
+++ b/src/main/java/org/highj/typeclass2/category/Lam2CCC.java
@@ -50,14 +50,7 @@ public class Lam2CCC<K,Tensor,Hom,Unit> {
     }
 
     public <X,I,A,B,C,D> __2<K,I,__3<Hom,K,A,__3<Hom,K,B,__3<Hom,K,C,D>>>> lam3Curried(__2<K,X,__3<Tensor,K,I,A>> cast, F1<__2<K,X,A>,F1<__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,B>,F1<__2<K, __3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>, C>, __2<K, __3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>, D>>>> f) {
-        return this.lam(cast, (__2<K, X, A> x) -> lam2Curried(ccc.exl(), f.apply(x)));
-    }
-
-    private void test() {
-        // type checking
-        apply(lam2Curried(x -> y -> x), null);
-        apply(lam2Curried(ccc.exl(), x -> y -> x), null);
-        apply(apply(lam3Curried(ccc.dot(ccc.exl(), ccc.exl()), x -> y -> z -> y), null), null);
+        return lam(cast, (__2<K, X, A> x) -> lam2Curried(ccc.exl(), f.apply(x)));
     }
 
     // ($) :: forall k i a b. CCC k => k i (Hom k a b) -> k i a -> k i b

--- a/src/main/java/org/highj/typeclass2/category/Lam2CCC.java
+++ b/src/main/java/org/highj/typeclass2/category/Lam2CCC.java
@@ -18,23 +18,23 @@ public class Lam2CCC<K,Tensor,Hom,Unit> {
     }
 
     public <I,A,B> __2<K,I,__3<Hom,K,A,B>> lam1(F1<__2<K,__3<Tensor,K,I,A>,A>,__2<K,__3<Tensor,K,I,A>,B>> f) {
-        return ccc.curry(f.apply(ccc.exr()));
+        return lam(ccc.identity(), f);
     }
 
     public <I,A,B,C> __2<K,I,__3<Hom,K,A,__3<Hom,K,B,C>>> lam2(F2<__2<K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,A>,__2<K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,B>,__2<K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>> f) {
-        return ccc.curry(ccc.curry(f.apply(ccc.dot(ccc.exr(), ccc.exl()), ccc.exr())));
+        return lam2Curried(a -> b -> f.apply(a, b));
     }
 
     public <I,A,B,C,D> __2<K,I,__3<Hom,K,A,__3<Hom,K,B,__3<Hom,K,C,D>>>> lam3(F3<__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,A>,__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,B>,__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,C>,__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,D>> f) {
-        return ccc.curry(ccc.curry(ccc.curry(f.apply(ccc.dot(ccc.exr(), ccc.dot(ccc.exl(), ccc.exl())), ccc.dot(ccc.exr(), ccc.exl()), ccc.exr()))));
+        return lam3Curried(a -> b -> c -> f.apply(a, b, c));
     }
 
     public <I,A,B,C> __2<K,I,__3<Hom,K,A,__3<Hom,K,B,C>>> lam2Curried(F1<__2<K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,A>,F1<__2<K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,B>,__2<K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>>> f) {
-        return lam2((x, y) -> f.apply(x).apply(y));
+        return lam2Curried(ccc.exl(), f);
     }
 
     public <I,A,B,C,D> __2<K,I,__3<Hom,K,A,__3<Hom,K,B,__3<Hom,K,C,D>>>> lam3Curried(F1<__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,A>,F1<__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,B>,F1<__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,C>,__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,D>>>> f) {
-        return lam3((x, y, z) -> f.apply(x).apply(y).apply(z));
+        return lam3Curried(ccc.dot(ccc.exl(), ccc.exl()), f);
     }
 
     // lam :: forall k i a b. CCC k => ((forall x. Cast k x (Tensor k i a) => k x a) -> k (Tensor k i a) b) -> k i (Hom k a b)

--- a/src/main/java/org/highj/typeclass2/category/Lam2CCC.java
+++ b/src/main/java/org/highj/typeclass2/category/Lam2CCC.java
@@ -57,4 +57,10 @@ public class Lam2CCC<K,Tensor,Hom,Unit> {
     public <I,A,B> __2<K,I,B> apply(__2<K,I,__3<Hom,K,A,B>> f, __2<K,I,A> a) {
         return ccc.dot(ccc.eval(), ccc.fork(f, a));
     }
+
+    // liftCCC :: forall k i a b. CCC k => k a b -> k i a -> k i b
+    // liftCCC = (.)
+    public <I,A,B> __2<K,I,B> liftCCC(__2<K,A,B> ab, __2<K,I,A> a) {
+        return ccc.dot(ab, a);
+    }
 }

--- a/src/main/java/org/highj/typeclass2/category/Lam2CCC.java
+++ b/src/main/java/org/highj/typeclass2/category/Lam2CCC.java
@@ -49,9 +49,23 @@ public class Lam2CCC<K,Tensor,Hom,Unit> {
         return lam(cast, (__2<K, X, A> x) -> lam(ccc.identity(), f.apply(x)));
     }
 
+    public <X,I,A,B,C,D> __2<K,I,__3<Hom,K,A,__3<Hom,K,B,__3<Hom,K,C,D>>>> lam3Curried(__2<K,X,__3<Tensor,K,I,A>> cast, F1<__2<K,X,A>,F1<__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,B>,F1<__2<K, __3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>, C>, __2<K, __3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>, D>>>> f) {
+        return this.lam(
+            cast,
+            (__2<K, X, A> x) ->
+                lam(
+                    ccc.exl(),
+                    (__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,B> x2) ->
+                        lam(ccc.identity(), f.apply(x).apply(x2))
+                )
+        );
+    }
+
     private void test() {
-        // type checks
+        // type checking
         apply(lam2Curried(x -> y -> x), null);
+        apply(lam2Curried(ccc.exl(), x -> y -> x), null);
+        apply(apply(lam3Curried(ccc.dot(ccc.exl(), ccc.exl()), x -> y -> z -> y), null), null);
     }
 
     // ($) :: forall k i a b. CCC k => k i (Hom k a b) -> k i a -> k i b

--- a/src/main/java/org/highj/typeclass2/category/Lam2CCC.java
+++ b/src/main/java/org/highj/typeclass2/category/Lam2CCC.java
@@ -45,6 +45,10 @@ public class Lam2CCC<K,Tensor,Hom,Unit> {
         return ccc.curry(f.apply(ccc.dot(ccc.exr(),cast)));
     }
 
+    public <X,I,A,B,C> __2<K, I, __3<Hom, K, A, __3<Hom, K, B, C>>> lam2Curried(__2<K,X,__3<Tensor,K,I,A>> cast, F1<__2<K,X,A>,F1<__2<K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,B>,__2<K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>>> f) {
+        return lam(cast, (__2<K, X, A> x) -> lam(ccc.identity(), f.apply(x)));
+    }
+
     private void test() {
         // type checks
         apply(lam2Curried(x -> y -> x), null);

--- a/src/main/java/org/highj/typeclass2/category/Lam2CCC.java
+++ b/src/main/java/org/highj/typeclass2/category/Lam2CCC.java
@@ -1,0 +1,45 @@
+package org.highj.typeclass2.category;
+
+import org.derive4j.hkt.__2;
+import org.derive4j.hkt.__3;
+import org.highj.function.F1;
+
+public class Lam2CCC<K,Tensor,Hom,Unit> {
+    private final CCC<K,Tensor,Hom,Unit> ccc;
+
+    private Lam2CCC(CCC<K,Tensor,Hom,Unit> ccc) {
+        this.ccc = ccc;
+    }
+
+    public static <K,Tensor,Hom,Unit> Lam2CCC<K,Tensor,Hom,Unit> create(CCC<K,Tensor,Hom,Unit> ccc) {
+        return new Lam2CCC<>(ccc);
+    }
+
+    /*
+    lam :: forall k i a b. CCC k => ((forall x. Cast k x (Tensor k i a) => k x a) -> k (Tensor k i a) b) -> k i (Hom k a b)
+    lam f = curry (f exr_) where
+      exr_ :: forall x. Cast k x (Tensor k i a) => k x a
+      exr_ = exr . (cast :: k x (Tensor k i a))
+    */
+    /* ??? (Requires Cast but if we use it, then the end-user needs to keep supplying it. It would not be implicit).
+    public <I,X,A,B> __2<K,I,__3<Hom,K,A,B>> lam(F1<__2<K,__3<X,A>,__2<K,__3<Tensor,K,I,A>,B>> f) {}
+    */
+
+    public <I,A,B> __2<K,I,__3<Hom,K,A,B>> lam_1(F1<__2<K,__3<Tensor,K,I,A>,A>,__2<K,__3<Tensor,K,I,A>,B>> f) {
+        return ccc.curry(f.apply(ccc.exr()));
+    }
+
+    public <I,X,A,B> __2<K,I,__3<Hom,K,A,B>> lam_2(F1<__2<K,__3<Tensor,K,X,__3<Tensor,K,I,A>>,A>,__2<K,__3<Tensor,K,I,A>,B>> f) {
+        return ccc.curry(f.apply(ccc.dot(ccc.exr(), ccc.exr())));
+    }
+
+    public <I,X1,X2,A,B> __2<K,I,__3<Hom,K,A,B>> lam_3(F1<__2<K,__3<Tensor,K,X1,__3<Tensor,K,X2,__3<Tensor,K,I,A>>>,A>,__2<K,__3<Tensor,K,I,A>,B>> f) {
+        return ccc.curry(f.apply(ccc.dot(ccc.exr(), ccc.dot(ccc.exr(), ccc.exr()))));
+    }
+
+    // ($) :: forall k i a b. CCC k => k i (Hom k a b) -> k i a -> k i b
+    // ($) f x = eval <<< fork f x
+    public <I,A,B> __2<K,I,B> apply(__2<K,I,__3<Hom,K,A,B>> f, __2<K,I,A> a) {
+        return ccc.dot(ccc.eval(), ccc.fork(f, a));
+    }
+}

--- a/src/main/java/org/highj/typeclass2/category/Lam2CCC.java
+++ b/src/main/java/org/highj/typeclass2/category/Lam2CCC.java
@@ -17,16 +17,6 @@ public class Lam2CCC<K,Tensor,Hom,Unit> {
         return new Lam2CCC<>(ccc);
     }
 
-    /*
-    lam :: forall k i a b. CCC k => ((forall x. Cast k x (Tensor k i a) => k x a) -> k (Tensor k i a) b) -> k i (Hom k a b)
-    lam f = curry (f exr_) where
-      exr_ :: forall x. Cast k x (Tensor k i a) => k x a
-      exr_ = exr . (cast :: k x (Tensor k i a))
-    */
-    /* ??? (Requires Cast but if we use it, then the end-user needs to keep supplying it. It would not be implicit).
-    public <I,X,A,B> __2<K,I,__3<Hom,K,A,B>> lam(F1<__2<K,__3<X,A>,__2<K,__3<Tensor,K,I,A>,B>> f) {}
-    */
-
     public <I,A,B> __2<K,I,__3<Hom,K,A,B>> lam1(F1<__2<K,__3<Tensor,K,I,A>,A>,__2<K,__3<Tensor,K,I,A>,B>> f) {
         return ccc.curry(f.apply(ccc.exr()));
     }
@@ -45,6 +35,14 @@ public class Lam2CCC<K,Tensor,Hom,Unit> {
 
     public <I,A,B,C,D> __2<K,I,__3<Hom,K,A,__3<Hom,K,B,__3<Hom,K,C,D>>>> lam3Curried(F1<__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,A>,F1<__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,B>,F1<__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,C>,__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,D>>>> f) {
         return lam3((x, y, z) -> f.apply(x).apply(y).apply(z));
+    }
+
+    // lam :: forall k i a b. CCC k => ((forall x. Cast k x (Tensor k i a) => k x a) -> k (Tensor k i a) b) -> k i (Hom k a b)
+    // lam f = curry (f exr_) where
+    //   exr_ :: forall x. Cast k x (Tensor k i a) => k x a
+    //   exr_ = exr . (cast :: k x (Tensor k i a))
+    public <X,I,A,B> __2<K,I,__3<Hom,K,A,B>> lam(__2<K,X,__3<Tensor,K,I,A>> cast, F1<__2<K,X,A>,__2<K,__3<Tensor,K,I,A>,B>> f) {
+        return ccc.curry(f.apply(ccc.dot(ccc.exr(),cast)));
     }
 
     private void test() {

--- a/src/main/java/org/highj/typeclass2/category/Lam2CCC.java
+++ b/src/main/java/org/highj/typeclass2/category/Lam2CCC.java
@@ -5,6 +5,7 @@ import org.derive4j.hkt.__3;
 import org.highj.function.F1;
 import org.highj.function.F2;
 import org.highj.function.F3;
+import org.highj.function.F4;
 
 public class Lam2CCC<K,Tensor,Hom,Unit> {
     private final CCC<K,Tensor,Hom,Unit> ccc;
@@ -29,12 +30,20 @@ public class Lam2CCC<K,Tensor,Hom,Unit> {
         return lam3Curried(a -> b -> c -> f.apply(a, b, c));
     }
 
+    public <I,A,B,C,D,E> __2<K,I,__3<Hom,K,A,__3<Hom,K,B,__3<Hom,K,C,__3<Hom,K,D,E>>>>> lam4Curried(F4<__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,D>,A>,__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,D>,B>,__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,D>,C>,__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,D>,D>,__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,D>,E>> f) {
+        return lam4Curried(a -> b -> c -> d -> f.apply(a, b, c, d));
+    }
+
     public <I,A,B,C> __2<K,I,__3<Hom,K,A,__3<Hom,K,B,C>>> lam2Curried(F1<__2<K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,A>,F1<__2<K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,B>,__2<K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>>> f) {
         return lam2Curried(ccc.exl(), f);
     }
 
     public <I,A,B,C,D> __2<K,I,__3<Hom,K,A,__3<Hom,K,B,__3<Hom,K,C,D>>>> lam3Curried(F1<__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,A>,F1<__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,B>,F1<__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,C>,__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,D>>>> f) {
         return lam3Curried(ccc.dot(ccc.exl(), ccc.exl()), f);
+    }
+
+    public <I,A,B,C,D,E> __2<K,I,__3<Hom,K,A,__3<Hom,K,B,__3<Hom,K,C,__3<Hom,K,D,E>>>>> lam4Curried(F1<__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,D>,A>,F1<__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,D>,B>,F1<__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,D>,C>, F1<__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,D>,D>,__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,D>,E>>>>> f) {
+        return lam4Curried(ccc.dot(ccc.exl(), ccc.dot(ccc.exl(), ccc.exl())), f);
     }
 
     // lam :: forall k i a b. CCC k => ((forall x. Cast k x (Tensor k i a) => k x a) -> k (Tensor k i a) b) -> k i (Hom k a b)
@@ -51,6 +60,10 @@ public class Lam2CCC<K,Tensor,Hom,Unit> {
 
     public <X,I,A,B,C,D> __2<K,I,__3<Hom,K,A,__3<Hom,K,B,__3<Hom,K,C,D>>>> lam3Curried(__2<K,X,__3<Tensor,K,I,A>> cast, F1<__2<K,X,A>,F1<__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,B>,F1<__2<K, __3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>, C>, __2<K, __3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>, D>>>> f) {
         return lam(cast, (__2<K, X, A> x) -> lam2Curried(ccc.exl(), f.apply(x)));
+    }
+
+    public <X,I,A,B,C,D,E> __2<K,I,__3<Hom,K,A,__3<Hom,K,B,__3<Hom,K,C,__3<Hom,K,D,E>>>>> lam4Curried(__2<K,X,__3<Tensor,K,I,A>> cast, F1<__2<K,X,A>,F1<__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,D>,B>,F1<__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,D>,C>, F1<__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,D>,D>,__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,D>,E>>>>> f) {
+        return lam(cast, (__2<K,X,A> x) -> lam3Curried(ccc.dot(ccc.exl(), ccc.exl()), f.apply(x)));
     }
 
     // ($) :: forall k i a b. CCC k => k i (Hom k a b) -> k i a -> k i b

--- a/src/main/java/org/highj/typeclass2/category/Lam2CCC.java
+++ b/src/main/java/org/highj/typeclass2/category/Lam2CCC.java
@@ -74,7 +74,19 @@ public class Lam2CCC<K,Tensor,Hom,Unit> {
 
     // liftCCC :: forall k i a b. CCC k => k a b -> k i a -> k i b
     // liftCCC = (.)
-    public <I,A,B> __2<K,I,B> liftCCC(__2<K,A,B> ab, __2<K,I,A> a) {
-        return ccc.dot(ab, a);
+    public <I,A,B> __2<K,I,B> liftCCC(__2<K,A,B> f, __2<K,I,A> a) {
+        return ccc.dot(f, a);
+    }
+
+    public <I,A,B,C> __2<K,I,C> liftCCC2(__2<K,A,__3<Hom,K,B,C>> f, __2<K,I,A> a, __2<K,I,B> b) {
+        return ccc.dot(ccc.eval(), ccc.fork(liftCCC(f, a), b));
+    }
+
+    public <I,A,B,C,D> __2<K,I,D> liftCCC3(__2<K,A,__3<Hom,K,B,__3<Hom,K,C,D>>> f, __2<K,I,A> a, __2<K,I,B> b, __2<K,I,C> c) {
+        return ccc.dot(ccc.eval(), ccc.fork(liftCCC2(f, a, b), c));
+    }
+
+    public <I,A,B,C,D,E> __2<K,I,E> liftCCC4(__2<K,A,__3<Hom,K,B,__3<Hom,K,C,__3<Hom,K,D,E>>>> f, __2<K,I,A> a, __2<K,I,B> b, __2<K,I,C> c, __2<K,I,D> d) {
+        return ccc.dot(ccc.eval(), ccc.fork(liftCCC3(f, a, b, c), d));
     }
 }

--- a/src/main/java/org/highj/typeclass2/category/Lam2CCC.java
+++ b/src/main/java/org/highj/typeclass2/category/Lam2CCC.java
@@ -50,15 +50,7 @@ public class Lam2CCC<K,Tensor,Hom,Unit> {
     }
 
     public <X,I,A,B,C,D> __2<K,I,__3<Hom,K,A,__3<Hom,K,B,__3<Hom,K,C,D>>>> lam3Curried(__2<K,X,__3<Tensor,K,I,A>> cast, F1<__2<K,X,A>,F1<__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,B>,F1<__2<K, __3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>, C>, __2<K, __3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>, D>>>> f) {
-        return this.lam(
-            cast,
-            (__2<K, X, A> x) ->
-                lam(
-                    ccc.exl(),
-                    (__2<K,__3<Tensor,K,__3<Tensor,K,__3<Tensor,K,I,A>,B>,C>,B> x2) ->
-                        lam(ccc.identity(), f.apply(x).apply(x2))
-                )
-        );
+        return this.lam(cast, (__2<K, X, A> x) -> lam2Curried(ccc.exl(), f.apply(x)));
     }
 
     private void test() {

--- a/src/test/java/org/highj/typeclass2/category/KTest.java
+++ b/src/test/java/org/highj/typeclass2/category/KTest.java
@@ -1,0 +1,27 @@
+package org.highj.typeclass2.category;
+
+import org.derive4j.hkt.__;
+import org.derive4j.hkt.__2;
+import org.derive4j.hkt.__3;
+import org.highj.Hkt;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class KTest {
+
+
+    private static <Unit,A> String debug(__2<K,__<Unit,K>,A> k) {
+        return Hkt.asK(k).optimize().prettyPrint();
+    }
+
+    private static <K,Tensor,Hom,Unit,I,A,B> __2<K,I,A> fst(CCC<K,Tensor,Hom,Unit> ccc, __2<K,I,__3<Tensor,K,A,B>> a) {
+        return Lam2CCC.create(ccc).liftCCC(ccc.exl(), a);
+    }
+
+    @Test
+    public void test1() {
+        String result = debug(Lam2CCC.create(K.ccc()).lam1(x -> x));
+        assertThat(result).isEqualTo("curry snd");
+    }
+}

--- a/src/test/java/org/highj/typeclass2/category/KTest.java
+++ b/src/test/java/org/highj/typeclass2/category/KTest.java
@@ -24,4 +24,10 @@ public class KTest {
         String result = debug(Lam2CCC.create(K.ccc()).lam1(x -> x));
         assertThat(result).isEqualTo("curry snd");
     }
+
+    @Test
+    public void test7() {
+        String result = debug(Lam2CCC.create(K.ccc()).lam2Curried(x -> _unused -> x));
+        assertThat(result).isEqualTo("curry (curry (snd . fst))");
+    }
 }


### PR DESCRIPTION
I'm thinking if we implement ```Cast```, then the end-user would have to keep supplying a ```Cast```. It would not be implicit like it is in Haskell.

There might still exist some Java tricks we can do.

This is at least a start. Will need to find a way to reduce ```lam_1```, ```lam_2```, etc. into just ```lam```.